### PR TITLE
feat: udistrital/sga_documentacion#129 Correciones para el recibo de pago, en el crud de inscripcion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ swagger/images/
 swagger/lang/
 swagger/lib/
 *.exe
+*.env
 go.mod
 go.sum

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ swagger/images/
 swagger/lang/
 swagger/lib/
 *.exe
+*.exe~
 *.env
 go.mod
 go.sum

--- a/controllers/inscripcion.go
+++ b/controllers/inscripcion.go
@@ -37,6 +37,7 @@ func (c *InscripcionController) URLMapping() {
 func (c *InscripcionController) Post() {
 	var v models.Inscripcion
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &v); err == nil {
+		v.ProgramaAcademicoId = nil
 		v.FechaCreacion = time_bogota.TiempoBogotaFormato()
 		v.FechaModificacion = time_bogota.TiempoBogotaFormato()
 		if _, err := models.AddInscripcion(&v); err == nil {

--- a/controllers/inscripcion.go
+++ b/controllers/inscripcion.go
@@ -37,7 +37,6 @@ func (c *InscripcionController) URLMapping() {
 func (c *InscripcionController) Post() {
 	var v models.Inscripcion
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &v); err == nil {
-		v.ProgramaAcademicoId = nil
 		v.FechaCreacion = time_bogota.TiempoBogotaFormato()
 		v.FechaModificacion = time_bogota.TiempoBogotaFormato()
 		if _, err := models.AddInscripcion(&v); err == nil {

--- a/database/migrations/20240409_181428_ajuste_programa_academico_inscripcion.go
+++ b/database/migrations/20240409_181428_ajuste_programa_academico_inscripcion.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"github.com/astaxie/beego/migration"
+)
+
+// DO NOT MODIFY
+type AjusteProgramaAcademicoInscripcion_20240409_181428 struct {
+	migration.Migration
+}
+
+// DO NOT MODIFY
+func init() {
+	m := &AjusteProgramaAcademicoInscripcion_20240409_181428{}
+	m.Created = "20240409_181428"
+
+	migration.Register("AjusteProgramaAcademicoInscripcion_20240409_181428", m)
+}
+
+// Run the migrations
+func (m *AjusteProgramaAcademicoInscripcion_20240409_181428) Up() {
+	m.SQL("ALTER TABLE inscripcion.inscripcion ALTER COLUMN programa_academico_id DROP NOT NULL")
+
+}
+
+// Reverse the migrations
+func (m *AjusteProgramaAcademicoInscripcion_20240409_181428) Down() {
+	m.SQL("ALTER TABLE inscripcion.inscripcion ALTER COLUMN programa_academico_id SET NOT NULL")
+}

--- a/models/inscripcion.go
+++ b/models/inscripcion.go
@@ -13,7 +13,7 @@ import (
 type Inscripcion struct {
 	Id                  int                `orm:"column(id);pk;auto"`
 	PersonaId           int                `orm:"column(persona_id)"`
-	ProgramaAcademicoId *int               `orm:"column(programa_academico_id)"`
+	ProgramaAcademicoId int                `orm:"column(programa_academico_id);null"`
 	ReciboInscripcion   string             `orm:"column(recibo_inscripcion);null"`
 	PeriodoId           int                `orm:"column(periodo_id)"`
 	EnfasisId           int                `orm:"column(enfasis_id);null"`

--- a/models/inscripcion.go
+++ b/models/inscripcion.go
@@ -13,7 +13,7 @@ import (
 type Inscripcion struct {
 	Id                  int                `orm:"column(id);pk;auto"`
 	PersonaId           int                `orm:"column(persona_id)"`
-	ProgramaAcademicoId int                `orm:"column(programa_academico_id)"`
+	ProgramaAcademicoId *int               `orm:"column(programa_academico_id)"`
 	ReciboInscripcion   string             `orm:"column(recibo_inscripcion);null"`
 	PeriodoId           int                `orm:"column(periodo_id)"`
 	EnfasisId           int                `orm:"column(enfasis_id);null"`


### PR DESCRIPTION
Mediante una migration se deja el campo ProgramaAcademicoId de la tabla inscripción, apto para recibir un dato nulo