### PR TITLE
feat: Agregar soporte para idioma nulo en la tabla inscripcion_posgrado.

### DIFF
--- a/database/migrations/20241007_073329_update_idioma_column_to_nullable.go
+++ b/database/migrations/20241007_073329_update_idioma_column_to_nullable.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"github.com/astaxie/beego/migration"
+)
+
+// DO NOT MODIFY
+type UpdateIdiomaColumnToNullable_20241007_073329 struct {
+	migration.Migration
+}
+
+// DO NOT MODIFY
+func init() {
+	m := &UpdateIdiomaColumnToNullable_20241007_073329{}
+	m.Created = "20241007_073329"
+
+	migration.Register("UpdateIdiomaColumnToNullable_20241007_073329", m)
+}
+
+// Run the migrations
+func (m *UpdateIdiomaColumnToNullable_20241007_073329) Up() {
+	// use m.SQL("CREATE TABLE ...") to make schema update
+	m.SQL("ALTER TABLE inscripcion.inscripcion_posgrado ALTER COLUMN idioma DROP NOT NULL;")
+}
+
+// Reverse the migrations
+func (m *UpdateIdiomaColumnToNullable_20241007_073329) Down() {
+	// use m.SQL("DROP TABLE ...") to reverse schema update
+	m.SQL("ALTER TABLE inscripcion.inscripcion_posgrado ALTER COLUMN idioma SET NOT NULL;")
+}

--- a/models/inscripcion_posgrado.go
+++ b/models/inscripcion_posgrado.go
@@ -11,7 +11,7 @@ import (
 
 type InscripcionPosgrado struct {
 	Id                int          `orm:"column(id);pk;auto"`
-	Idioma            int          `orm:"column(idioma)"`
+	Idioma            *int         `orm:"column(idioma);null"`
 	Activo            bool         `orm:"column(activo)"`
 	FechaCreacion     string       `orm:"column(fecha_creacion);type(timestamp without time zone)"`
 	FechaModificacion string       `orm:"column(fecha_modificacion);type(timestamp without time zone)"`


### PR DESCRIPTION
- Al momento de eliminar el idioma que tiene el check de `¿Desea usar este idioma para su examen?` es necesario dejar en null el valor de idioma en la tabla inscripcion_posgrado. Con el objetivo de que el usuario pueda volver a registrar un idioma con el check de `¿Desea usar este idioma para su examen?`.
---
udistrital/sga_documentacion#509